### PR TITLE
Flush stdout when stdin is called

### DIFF
--- a/src/pypyjs.js
+++ b/src/pypyjs.js
@@ -286,6 +286,10 @@ function pypyjs(opts) {
 
     // Route stdin to an overridable method on the object.
     const stdin = () => {
+      if (stdoutBuffer.length) {
+        this.stdout(stdoutBuffer.join(''));
+        stdoutBuffer = [];
+      }
       return this.stdin();
     };
 


### PR DESCRIPTION
Fixes `raw_input` such that the input prompt prints before the user is asked for input
